### PR TITLE
add DATA_VERSION 2 to froggen.settings

### DIFF
--- a/config/dum/froggen.settings
+++ b/config/dum/froggen.settings
@@ -1,3 +1,4 @@
+DATA_VERSION 2
 e <utt>
 l froggen.data.lex.ambi.05
 k froggen.data.known.dddwfWawa

--- a/config/nld-vnn/froggen.settings
+++ b/config/nld-vnn/froggen.settings
@@ -1,3 +1,4 @@
+DATA_VERSION 2
 e <utt>
 l froggen.data.lex.ambi.05
 k froggen.data.known.dddwfWawa


### PR DESCRIPTION
I tried to run frog-dum and frog-nld-vnn from docker.

`docker run proycon/frog -c /usr/share/frog/dum/frog.cfg`

This results in

```
/usr/share/frog/dum/froggen.settings has a PROBLEM!
No DATA_VERSION setting is found but this version of MbT expects at least 2
Cannot read settingsfile /usr/share/frog/dum/froggen.settings
ucto: textcat configured from: /usr/share/ucto/textcat.cfg
frog-:Initialization failed for: [tagger] 
frog-:fatal error: Frog init failed
```
For now I fix this by extending the docker image and copying custom setting files with the DATA VERSION prepended.

```
COPY froggen.settings /usr/share/frog/dum/froggen.settings
COPY froggen.settings /usr/share/frog/nld-vnn/froggen.settings
```

I do however not know whether the files are actually 'DATA_VERSION'  2. If they are, this PR seems to fix the problem. Otherwise I need another solution.